### PR TITLE
Fix object upload filepath in Windows

### DIFF
--- a/src/commands/data-management.ts
+++ b/src/commands/data-management.ts
@@ -222,7 +222,7 @@ export async function uploadObject(bucket: IBucket | undefined, context: IContex
 		return;
 	}
 
-	const filepath = uri[0].path;
+	const filepath = process.platform === 'win32' ? uri[0].path.substr(1) : uri[0].path;
 	let fd = -1;
     try {
 		fd = fs.openSync(filepath, 'r');


### PR DESCRIPTION
Check for win32 platform and if so strip the leading / from filepath.