### PR TITLE
Issue 19 - Adding Translate Object feature to Versions in the Hubs View

### DIFF
--- a/package.json
+++ b/package.json
@@ -533,7 +533,12 @@
 				},
 				{
 					"command": "forge.translateObject",
-					"when": "viewItem == object || viewItem == version",
+					"when": "view == forgeDataManagementView && viewItem == object",
+					"group": "1_action_md@2"
+				},
+				{
+					"command": "forge.translateObject",
+					"when": "view == forgeHubsView && viewItem == version",
 					"group": "1_action_md@2"
 				},
 				{

--- a/package.json
+++ b/package.json
@@ -533,7 +533,7 @@
 				},
 				{
 					"command": "forge.translateObject",
-					"when": "view == forgeDataManagementView && viewItem == object",
+					"when": "viewItem == object || viewItem == version",
 					"group": "1_action_md@2"
 				},
 				{

--- a/src/commands/authentication.ts
+++ b/src/commands/authentication.ts
@@ -3,11 +3,18 @@ import * as url from 'url';
 import * as vscode from 'vscode';
 import { IContext, showErrorMessage } from '../common';
 
-const DefaultScopes = ['viewables:read', 'bucket:read', 'bucket:create', 'data:read', 'data:create', 'data:write', 'code:all']; // Make this list configurable?
+const DefaultScopes = [
+    'viewables:read', 
+    'code:all', 
+    'bucket:create','bucket:read','bucket:update', 'bucket:delete', 
+    'data:read', 'data:write', 'data:create', 'data:search',
+    'account:read', 'account:write', 
+    'user:read', 'user:write',
+    'user-profile:read']; // Make this list configurable?
 
 export async function login(clientId: string, port: number, context: IContext): Promise<Map<string, string>> {
     const timeout = 2 * 60 * 1000; // Wait for 2 minutes
-    const scopes = ['data:read', 'viewables:read'];
+    const scopes = DefaultScopes; 
     return new Promise(function (resolve, reject) {
         const server = http.createServer(function (req, res) {
             if (req.url === '/') {

--- a/src/commands/model-derivative.ts
+++ b/src/commands/model-derivative.ts
@@ -26,7 +26,6 @@ function urnify(id: string): string {
 	return _urnify(id).replace('/', '_');
 }
 
-//hi.IVersion
 export async function translateObject(object: IObject | hi.IVersion | undefined, context: IContext) {
 	try {
 		if (!object) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,7 @@ import * as mdc from './commands/model-derivative';
 import * as dac from './commands/design-automation';
 import * as dai from './interfaces/design-automation';
 import * as mdi from './interfaces/model-derivative';
+import * as hi  from './interfaces/hubs';
 import { Region } from 'forge-server-utils/dist/common';
 import { TemplateEngine, IContext } from './common';
 import { WebhooksDataProvider, IWebhook, IWebhookEvent } from './providers/webhooks';
@@ -125,6 +126,12 @@ export function activate(_context: vscode.ExtensionContext) {
 	let dataManagementView = vscode.window.createTreeView('forgeDataManagementView', { treeDataProvider: simpleStorageDataProvider });
 	context.extensionContext.subscriptions.push(dataManagementView);
 
+	
+	// Setup hubs view
+	let hubsDataProvider = new HubsDataProvider(context);
+	let hubsView = vscode.window.createTreeView('forgeHubsView', { treeDataProvider: hubsDataProvider });
+	context.extensionContext.subscriptions.push(hubsView);
+
 	// Data management commands
 	vscode.commands.registerCommand('forge.refreshBuckets', () => {
 		simpleStorageDataProvider.refresh();
@@ -175,9 +182,10 @@ export function activate(_context: vscode.ExtensionContext) {
 	});
 
 	// Model derivative commands
-	vscode.commands.registerCommand('forge.translateObject', async (object?: IObject) => {
+	vscode.commands.registerCommand('forge.translateObject', async (object?: IObject | hi.IVersion) => {
 		await mdc.translateObject(object, context);
-		simpleStorageDataProvider.refresh(object);
+		simpleStorageDataProvider.refresh((object as IObject));
+		hubsDataProvider.refresh((object as hi.IVersion));
 	});
 	vscode.commands.registerCommand('forge.translateObjectCustom', async (object?: IObject) => {
 		await mdc.translateObjectCustom(object, context, () => { simpleStorageDataProvider.refresh(object); });
@@ -217,10 +225,6 @@ export function activate(_context: vscode.ExtensionContext) {
 		await mdc.copyObjectUrn(object, context);
 	});
 
-	// Setup hubs view
-	let hubsDataProvider = new HubsDataProvider(context);
-	let hubsView = vscode.window.createTreeView('forgeHubsView', { treeDataProvider: hubsDataProvider });
-	context.extensionContext.subscriptions.push(hubsView);
 
 	// Hubs commands
 	// vscode.commands.registerCommand('forge.refreshBuckets', () => {

--- a/src/interfaces/hubs.ts
+++ b/src/interfaces/hubs.ts
@@ -1,0 +1,38 @@
+export interface IHint {
+    hint: string;
+    tooltip?: string;
+}
+
+export interface IHub {
+    kind: 'hub';
+    id: string;
+    name: string;
+}
+
+export interface IProject {
+    kind: 'project';
+    hubId: string;
+    id: string;
+    name: string;
+}
+
+export interface IFolder {
+    kind: 'folder';
+    projectId: string;
+    id: string;
+    name: string;
+}
+
+export interface IItem {
+    kind: 'item';
+    projectId: string;
+    id: string;
+    name: string;
+}
+
+export interface IVersion {
+    kind: 'version';
+    itemId: string;
+    id: string;
+    name: string;
+}


### PR DESCRIPTION
**ISSUE**

https://github.com/petrbroz/vscode-forge-tools/issues/19

**DESCRIPTION**

Adding the "Translate Object" feature when right clicking on a version in the Hubs view.
This is a first action supported for issue number 19.

* The Hubs item types have been moved within a separate file in the interface folder so that we can use these types in model derivative commands or in the extension.

* The TranslateObject command definition has been updated in package so that it targets both "Objects" in data management and "Versions" in Hubs view.

* Updated the authentication scopes so our token has the right to trigger a translation.

* The translate Object command code now supports both Objects and Versions

* Refreshing the hubs view after TranslateObject command is executed so that we can start tracking the SVF manifest status and update progress, success or failures accordingly.