### PR TITLE
Set SVF2 as default translation output format

### DIFF
--- a/resources/templates/custom-translation.pug
+++ b/resources/templates/custom-translation.pug
@@ -16,7 +16,7 @@ html(lang='en')
         .col-sm-10
           select#output-format.form-control
             option(value="svf") SVF
-            option(value="svf2") SVF2
+            option(value="svf2" selected) SVF2
       // Root Filename
       .form-group.row
         label.col-sm-2.form-label(for='root-filename') Root Filename

--- a/src/commands/model-derivative.ts
+++ b/src/commands/model-derivative.ts
@@ -75,7 +75,7 @@ export async function translateObject(object: IObject | hi.IVersion | undefined,
 
 		let urn = getURN(object);
 		let client = getModelDerivativeClientForObject(object, context);
-		client.submitJob(urn, [{ type: 'svf', views: ['2d', '3d'] }], undefined, true);
+		client.submitJob(urn, [{ type: 'svf2', views: ['2d', '3d'] }], undefined, true);
 		vscode.window.showInformationMessage(`Translation started. Expand the object in the tree to see details.`);
 	} catch (err) {
 		showErrorMessage('Could not translate object', err);


### PR DESCRIPTION
March's _Devdays Forge Updates_ say:
> Model Derivative API now uses and returns SVF2 by default.

So the translation commands should also use SVF2.