### PR TITLE
Non svf(2) model derivatives

### DIFF
--- a/package.json
+++ b/package.json
@@ -304,6 +304,11 @@
 				"category": "Model Derivative"
 			},
 			{
+				"command": "forge.downloadDerivativeCustom",
+				"title": "Download Non-SVF derivatives",
+				"category": "Model Derivative"
+			},
+			{
 				"command": "forge.refreshDesignAutomationTree",
 				"title": "Refresh Design Automation Tree",
 				"category": "Design Automation",
@@ -650,6 +655,11 @@
 					"command": "forge.downloadDerivativeGltf",
 					"when": "view == apsDataManagementView && viewItem == object",
 					"group": "1_action_md@7"
+				},
+				{
+					"command": "forge.downloadDerivativeCustom",
+					"when": "view == apsDataManagementView && viewItem == non-viewable-derivative",
+					"group": "1_action_md@8"
 				},
 				{
 					"command": "forge.deleteObject",

--- a/src/commands/model-derivative.ts
+++ b/src/commands/model-derivative.ts
@@ -55,9 +55,7 @@ function getURN(object: IObject | hi.IVersion): string{
 
 function getFileExtension(object: IObject | hi.IVersion): string {
 	if ("objectKey" in object) {
-		const pathParts = object.objectKey.split(".");
-
-		return pathParts[pathParts.length - 1].toLowerCase();
+		return path.extname(object.objectKey).substring(1).toLowerCase();
 	}
 	return "";
 }

--- a/src/commands/model-derivative.ts
+++ b/src/commands/model-derivative.ts
@@ -14,7 +14,7 @@ import {
 	ModelDerivativeClient
 } from 'forge-server-utils';
 import { SvfReader, GltfWriter, SvfDownloader, F2dDownloader } from 'forge-convert-utils';
-import { IContext, promptBucket, promptObject, promptDerivative, showErrorMessage, inHubs } from '../common';
+import { IContext, promptBucket, promptObject, promptDerivative, showErrorMessage, inHubs, promptCustomDerivative } from '../common';
 import { IDerivative } from '../interfaces/model-derivative';
 import * as hi from '../interfaces/hubs';
 import { withProgress, createWebViewPanel, createViewerWebViewPanel } from '../common';
@@ -670,6 +670,31 @@ export async function downloadDerivativeGLTF(object: IObject | undefined, contex
 		}
 	} catch (err) {
 		showErrorMessage(`Could not convert derivatives`, err);
+	}
+}
+
+export async function downloadDerivativesCustom(object: IDerivative | undefined, context: IContext) {
+	try {
+		if (!object) {
+			const bucket = await promptBucket(context);
+			if (!bucket) {
+				return;
+			}
+			const bucketObject = await promptObject(context, bucket.bucketKey);
+			if (!bucketObject) {
+				return;
+			}
+
+			const formats = await getModelDerivativeFormats(context);
+
+			object = await promptCustomDerivative(context, bucketObject.objectId, formats);
+
+			if (!object) {
+				return;
+			}
+		}
+	} catch (err) {
+		showErrorMessage(`Could not download the derivative`, err);
 	}
 }
 

--- a/src/commands/model-derivative.ts
+++ b/src/commands/model-derivative.ts
@@ -109,6 +109,18 @@ export async function translateObject(object: IObject | hi.IVersion | undefined,
 			}
 		}
 
+		const formats = await getModelDerivativeFormats(context);
+
+		const extension = getFileExtension(object);
+
+		const availableFormats = formats.findAvailableOutputFormats(extension);
+
+		if (!availableFormats.find(x => x === svf2)) {
+			showErrorMessage("The conversion to SVF2 is not supported for this file by Model derivative service", {});
+
+			return;
+		}
+
 		let urn = getURN(object);
 		let client = getModelDerivativeClientForObject(object, context);
 		client.submitJob(urn, [{ type: svf2, views: ['2d', '3d'] }], undefined, true);

--- a/src/commands/model-derivative.ts
+++ b/src/commands/model-derivative.ts
@@ -19,6 +19,7 @@ import { IDerivative } from '../interfaces/model-derivative';
 import * as hi from '../interfaces/hubs';
 import { withProgress, createWebViewPanel, createViewerWebViewPanel } from '../common';
 import { ICustomDerivativeMessage, ICustomDerivativeProps } from '../webviews/custom-translation';
+import { svf2 } from '../providers/model-derivative';
 
 enum TranslationActions {
 	Translate = 'Translate',
@@ -103,7 +104,7 @@ export async function translateObject(object: IObject | hi.IVersion | undefined,
 
 		let urn = getURN(object);
 		let client = getModelDerivativeClientForObject(object, context);
-		client.submitJob(urn, [{ type: 'svf2', views: ['2d', '3d'] }], undefined, true);
+		client.submitJob(urn, [{ type: svf2, views: ['2d', '3d'] }], undefined, true);
 		vscode.window.showInformationMessage(`Translation started. Expand the object in the tree to see details.`);
 	} catch (err) {
 		showErrorMessage('Could not translate object', err);
@@ -196,11 +197,11 @@ export async function previewDerivative(derivative: IDerivative | undefined, con
 			: await context.authenticationClient.authenticate(['viewables:read']);
 		let env = context.previewSettings.env;
 		if (!env) {
-			env = derivative.format === 'svf2' ? 'AutodeskProduction2' : 'AutodeskProduction';
+			env = derivative.format === svf2 ? 'AutodeskProduction2' : 'AutodeskProduction';
 		}
 		let api = context.previewSettings.api;
 		if (!api) {
-			api = derivative.format === 'svf2' ? 'streamingV2' : 'derivativeV2';
+			api = derivative.format === svf2 ? 'streamingV2' : 'derivativeV2';
 			if (context.environment.region === 'EMEA') {
 				api += '_EU';
 			}

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as path from 'path';
 import {
     AuthenticationClient,
     DataManagementClient,
@@ -92,12 +93,10 @@ export async function promptCustomDerivative(context: IContext, objectId: string
         .flatMap((deriv: any) => deriv.children.filter((child: any) => child.role === deriv.outputType))
         .map((resource: any) => {
             const fileUrn: string = resource.urn;
-            const filePathParts = fileUrn.split("/");
-
 
             return {
                 urn,
-                name: filePathParts[filePathParts.length - 1],
+                name: path.basename(fileUrn),
                 role: resource.role,
                 guid: resource.guid,
                 format: resource.role,

--- a/src/common.ts
+++ b/src/common.ts
@@ -13,6 +13,7 @@ import {
 import { IDerivative } from './interfaces/model-derivative';
 import { IAuthOptions } from 'forge-server-utils/dist/common';
 import { IEnvironment } from './environments';
+import { isViewableFormat } from './providers/model-derivative';
 
 export interface IPreviewSettings {
     extensions: string[];
@@ -58,7 +59,7 @@ export async function promptObject(context: IContext, bucketKey: string): Promis
 export async function promptDerivative(context: IContext, objectId: string): Promise<IDerivative | undefined> {
     const urn = urnify(objectId);
     const manifest = await context.modelDerivativeClient2L.getManifest(urn) as any;
-    const svf = manifest.derivatives.find((deriv: any) => deriv.outputType === 'svf');
+    const svf = manifest.derivatives.find((deriv: any) => isViewableFormat(deriv.outputType));
     if (!svf) {
         vscode.window.showWarningMessage(`No derivatives yet for ${urn}`);
         return undefined;

--- a/src/common.ts
+++ b/src/common.ts
@@ -146,7 +146,7 @@ export async function showErrorMessage(title: string, err: any) {
                 statusText: err.response.statusText
             };
             const doc = await vscode.workspace.openTextDocument({ content: JSON.stringify(raw, null, 4), language: 'json' });
-		    await vscode.window.showTextDocument(doc, { preview: false });
+            await vscode.window.showTextDocument(doc, { preview: false });
         }
     } else {
         await vscode.window.showErrorMessage(msg);

--- a/src/common.ts
+++ b/src/common.ts
@@ -87,7 +87,7 @@ export async function promptCustomDerivative(context: IContext, objectId: string
     const manifest = await context.modelDerivativeClient2L.getManifest(urn) as any;
 
     const derivatives: IDerivative[] = manifest.derivatives
-        .find((deriv: any) => formats.hasOutput(deriv.outputType))
+        .filter((deriv: any) => formats.hasOutput(deriv.outputType))
         .filter((deriv: any) => !isViewableFormat(deriv.outputType))
         .flatMap((deriv: any) => deriv.children.filter((child: any) => child.role === deriv.outputType))
         .map((resource: any) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -435,6 +435,9 @@ function registerModelDerivativeCommands(context: IContext, simpleStorageDataPro
     vscode.commands.registerCommand('forge.downloadDerivativeGltf', async (object?: IObject) => {
         await mdc.downloadDerivativeGLTF(object, context);
     });
+    vscode.commands.registerCommand('forge.downloadDerivativeCustom', async (object?: mdi.IDerivative) => {
+        await mdc.downloadDerivativesCustom(object, context);
+    })
     vscode.commands.registerCommand('forge.copyObjectUrn', async (object?: IObject | hi.IVersion) => {
         await mdc.copyObjectUrn(object, context);
     });

--- a/src/interfaces/model-derivative.ts
+++ b/src/interfaces/model-derivative.ts
@@ -5,4 +5,5 @@ export interface IDerivative {
     guid: string;
     format: string;
     bubble: any;
+    nonViewable?: boolean;
 }

--- a/src/providers/data-management.ts
+++ b/src/providers/data-management.ts
@@ -139,7 +139,9 @@ export class SimpleStorageDataProvider implements vscode.TreeDataProvider<Simple
                     role: resource.role,
                     guid: resource.guid,
                     format: derivative.outputType,
-                    bubble: {},
+                    bubble: {
+                        fileUrn
+                    },
                     nonViewable: true
                 }
             });

--- a/src/providers/data-management.ts
+++ b/src/providers/data-management.ts
@@ -60,7 +60,7 @@ export class SimpleStorageDataProvider implements vscode.TreeDataProvider<Simple
             return node;
         } else if (isDerivative(element)) {
             const node = new vscode.TreeItem(element.name, vscode.TreeItemCollapsibleState.None);
-            node.contextValue = 'derivative';
+            node.contextValue = element.nonViewable ? 'non-viewable-derivative' : 'derivative';
             node.iconPath = new vscode.ThemeIcon('file-binary');
             return node;
         } else {
@@ -139,7 +139,8 @@ export class SimpleStorageDataProvider implements vscode.TreeDataProvider<Simple
                     role: resource.role,
                     guid: resource.guid,
                     format: derivative.outputType,
-                    bubble: {}
+                    bubble: {},
+                    nonViewable: true
                 }
             });
         }

--- a/src/providers/data-management.ts
+++ b/src/providers/data-management.ts
@@ -7,7 +7,7 @@ import {
 } from 'forge-server-utils';
 import { IDerivative } from '../interfaces/model-derivative';
 import { IContext, stringPropertySorter, showErrorMessage } from '../common';
-import { ModelDerivativeFormats } from './model-derivative';
+import { ModelDerivativeFormats, isViewableFormat } from './model-derivative';
 
 export interface IHint {
     hint: string;
@@ -117,7 +117,7 @@ export class SimpleStorageDataProvider implements vscode.TreeDataProvider<Simple
 
         const derivative = manifest.derivatives.find((deriv: any) => formats.hasOutput(deriv.outputType));
 
-        if (derivative.outputType === 'svf' || derivative.outputType === 'svf2') {
+        if (isViewableFormat(derivative.outputType)) {
             return derivative.children.filter((child: any) => child.type === 'geometry').map((geometry: any) => {
                 return {
                     urn: urn,

--- a/src/providers/data-management.ts
+++ b/src/providers/data-management.ts
@@ -130,8 +130,8 @@ export class SimpleStorageDataProvider implements vscode.TreeDataProvider<Simple
             });
         } else {
             return derivative.children.filter((child: any) => child.role === derivative.outputType).map((resource: any) => {
-                const urn: string = resource.urn;
-                const filePathParts = urn.split("/");
+                const fileUrn: string = resource.urn;
+                const filePathParts = fileUrn.split("/");
 
                 return {
                     urn,

--- a/src/providers/data-management.ts
+++ b/src/providers/data-management.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as path from 'path';
 import {
 	IBucket,
     IObject,
@@ -131,11 +132,10 @@ export class SimpleStorageDataProvider implements vscode.TreeDataProvider<Simple
         } else {
             return derivative.children.filter((child: any) => child.role === derivative.outputType).map((resource: any) => {
                 const fileUrn: string = resource.urn;
-                const filePathParts = fileUrn.split("/");
 
                 return {
                     urn,
-                    name: filePathParts[filePathParts.length - 1],
+                    name: path.basename(fileUrn),
                     role: resource.role,
                     guid: resource.guid,
                     format: derivative.outputType,

--- a/src/providers/hubs.ts
+++ b/src/providers/hubs.ts
@@ -8,6 +8,7 @@ import {
 import { IDerivative } from '../interfaces/model-derivative';
 import { IContext, inHubs } from '../common';
 import * as hi from '../interfaces/hubs';
+import { isViewableFormat } from './model-derivative';
 
 function urnify(id: string): string {
     return _urnify(id).replace('/', '_');
@@ -255,7 +256,7 @@ export class HubsDataProvider implements vscode.TreeDataProvider<HubsEntry> {
             if (manifest.status !== 'success') {
                 throw new Error('Unexpected manifest status: ' + manifest.status);
             }
-            const svf = manifest.derivatives.find((deriv: any) => deriv.outputType === 'svf' || deriv.outputType === 'svf2');
+            const svf = manifest.derivatives.find((deriv: any) => isViewableFormat(deriv.outputType));
             if (!svf || !svf.children) {
                 return [];
             } else {
@@ -265,7 +266,7 @@ export class HubsDataProvider implements vscode.TreeDataProvider<HubsEntry> {
                         name: geometry.name,
                         role: geometry.role,
                         guid: geometry.guid,
-                        format: svf.outputType || 'svf',
+                        format: svf.outputType!,
                         bubble: geometry
                     };
                 });

--- a/src/providers/model-derivative.ts
+++ b/src/providers/model-derivative.ts
@@ -1,0 +1,58 @@
+import { IContext } from "../common";
+
+export class ModelDerivativeFormats {
+    private readonly _outputFormats = new Set<string>();
+    private readonly _outputFormatsBySourceFormat = new Map<string, string[]>();
+
+    constructor(availableTranslations: DerivativeTranslation[]) {
+        for (const derivativeTranslation of availableTranslations) {
+            this._outputFormats.add(derivativeTranslation.outputFormat);
+            this.outputFormats.push(derivativeTranslation.outputFormat);
+
+            for (const sourceFormat of derivativeTranslation.sourceFormats) {
+                const outputFormats = this._outputFormatsBySourceFormat.get(sourceFormat) || [];
+
+                outputFormats.push(derivativeTranslation.outputFormat);
+
+                this._outputFormatsBySourceFormat.set(sourceFormat, outputFormats);
+            }
+        }
+    }
+
+    readonly outputFormats: string[] = [];
+
+    static async create(context: IContext) {
+        const availableTranslations = await getAvailableTranslations(context);
+
+        return new ModelDerivativeFormats(availableTranslations);
+    }
+
+    hasOutput(outputFormat: string): boolean {
+        return this._outputFormats.has(outputFormat);
+    }
+
+    findAvailableOutputFormats(sourceFormat: string): string[] {
+        return this._outputFormatsBySourceFormat.get(sourceFormat) || [];
+    }
+}
+
+type DerivativeTranslation = {
+    outputFormat: string;
+    sourceFormats: string[];
+}
+
+const getAvailableTranslations = async (context: IContext): Promise<DerivativeTranslation[]> => {
+    const availableTranslations: DerivativeTranslation[] = [];
+
+    const formats = await context.modelDerivativeClient2L.formats();
+
+    for (const outputFormat in formats) {
+        if (Object.prototype.hasOwnProperty.call(formats, outputFormat)) {
+            const sourceFormats = formats[outputFormat];
+
+            availableTranslations.push({ outputFormat, sourceFormats });
+        }
+    }
+
+    return availableTranslations;
+}

--- a/src/providers/model-derivative.ts
+++ b/src/providers/model-derivative.ts
@@ -36,6 +36,11 @@ export class ModelDerivativeFormats {
     }
 }
 
+export const svf = "svf" as const;
+export const svf2 = "svf2" as const;
+
+export const isViewableFormat = (format: string) => format === svf || format === svf2;
+
 type DerivativeTranslation = {
     outputFormat: string;
     sourceFormats: string[];

--- a/src/webviews/custom-translation.tsx
+++ b/src/webviews/custom-translation.tsx
@@ -25,7 +25,7 @@ export interface ICustomDerivativeMessage {
 }
 
 const CustomDerivative = ({ urn, availableFormats }: ICustomDerivativeProps) => {
-    const [outputFormat, setOutputFormat] = useState(svf2);
+    const [outputFormat, setOutputFormat] = useState(availableFormats.find(x => x === svf2) || availableFormats[0]);
     const [rootFilename, setRootFilename] = useState('');
     const [switchLoader, setSwitchLoader] = useState(false);
     const [generateMasterViews, setGenerateMasterViews] = useState(false);
@@ -46,6 +46,8 @@ const CustomDerivative = ({ urn, availableFormats }: ICustomDerivativeProps) => 
         });
     }
 
+    const outputFormats = availableFormats.map(x => <VSCodeOption value={x} key={x}>Output format: {x.toUpperCase()}</VSCodeOption>)
+
     return (
         <div>
             <h1>Custom Translation</h1>
@@ -54,8 +56,7 @@ const CustomDerivative = ({ urn, availableFormats }: ICustomDerivativeProps) => 
 
                 {/* TODO: add label to the dropdown */}
                 <VSCodeDropdown value={outputFormat} onChange={ev => setOutputFormat((ev.target as any).value)}>
-                    <VSCodeOption value="svf">Output format: SVF</VSCodeOption>
-                    <VSCodeOption value="svf2">Output format: SVF2</VSCodeOption>
+                    {outputFormats}
                 </VSCodeDropdown>
                 <VSCodeTextField value={rootFilename} onChange={ev => setRootFilename((ev.target as any).value)}>Root Filename</VSCodeTextField>
 

--- a/src/webviews/custom-translation.tsx
+++ b/src/webviews/custom-translation.tsx
@@ -9,6 +9,7 @@ import { svf2 } from '../providers/model-derivative';
 
 export interface ICustomDerivativeProps {
     urn: string;
+    availableFormats: string[];
 }
 
 export interface ICustomDerivativeMessage {
@@ -23,7 +24,7 @@ export interface ICustomDerivativeMessage {
     }
 }
 
-const CustomDerivative = ({ urn }: ICustomDerivativeProps) => {
+const CustomDerivative = ({ urn, availableFormats }: ICustomDerivativeProps) => {
     const [outputFormat, setOutputFormat] = useState(svf2);
     const [rootFilename, setRootFilename] = useState('');
     const [switchLoader, setSwitchLoader] = useState(false);

--- a/src/webviews/custom-translation.tsx
+++ b/src/webviews/custom-translation.tsx
@@ -5,6 +5,7 @@ import { VSCodeTextField, VSCodeDropdown, VSCodeOption, VSCodeCheckbox, VSCodeBu
 import { postMessage } from './common';
 import { Grid } from './components/Grid';
 import { Actions } from './components/Actions';
+import { svf2 } from '../providers/model-derivative';
 
 export interface ICustomDerivativeProps {
     urn: string;
@@ -23,7 +24,7 @@ export interface ICustomDerivativeMessage {
 }
 
 const CustomDerivative = ({ urn }: ICustomDerivativeProps) => {
-    const [outputFormat, setOutputFormat] = useState('svf2');
+    const [outputFormat, setOutputFormat] = useState(svf2);
     const [rootFilename, setRootFilename] = useState('');
     const [switchLoader, setSwitchLoader] = useState(false);
     const [generateMasterViews, setGenerateMasterViews] = useState(false);


### PR DESCRIPTION
Hi @petrbroz ,

In this PR I added a support for non-SVF(2) translations using Model Derivative service:

1. Show the derivatives in the tree if they are not SVF or SVF2 
2. Add an ability to download such files using context menu or a command
![Treeview](https://github.com/petrbroz/vscode-forge-tools/assets/14212214/2bf1b875-2fa8-4715-8890-1aeb174ac948)
3. Add an ability to select target available output file format from the list in the custom translation dialog
![Custom translation](https://github.com/petrbroz/vscode-forge-tools/assets/14212214/174a79ae-a4ab-4f19-8237-08c0651e0b3c)
(SVF2 is still a default option if it's available there)